### PR TITLE
Include sys/socket.h for build on OpenBSD

### DIFF
--- a/udp-link.c
+++ b/udp-link.c
@@ -8,6 +8,7 @@
 #include <time.h>
 #include <ctype.h>
 #include <poll.h>
+#include <sys/socket.h>
 #include <sys/wait.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>


### PR DESCRIPTION
To solve for missing constant

```
$ make CC=cc
cc -c -Wall -O2 -ggdb -o udp-link.o udp-link.c
udp-link.c:290:34: error: use of undeclared identifier 'AF_INET'
        target_addr.sin_family = AF_INET;
...
```